### PR TITLE
Cleanup

### DIFF
--- a/Injection/InjectTest/AppDelegate.swift
+++ b/Injection/InjectTest/AppDelegate.swift
@@ -9,10 +9,6 @@ import Cocoa
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
-
-    
-
-
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
@@ -24,7 +20,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         return true
     }
-
-
 }
-

--- a/Injection/InjectTest/ViewController.swift
+++ b/Injection/InjectTest/ViewController.swift
@@ -9,22 +9,26 @@ import Cocoa
 import Injection
 
 class ViewController: NSViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        Inject.injectMachO(machoPath: "/Users/admin/Desktop/Code/inject/inject", cmdType: LC_Type.LOAD_DYLIB, backup: false, injectPath: "@executable_path/testMac/libtestinject.dylib") { result in
+        Inject.injectMachO(machoPath: "/Users/admin/Desktop/Code/inject/inject",
+                           cmdType: LC_Type.LOAD_DYLIB,
+                           backup: false,
+                           injectPath: "@executable_path/testMac/libtestinject.dylib") { result in
             if result {
-                Shell.run("otool -L /Users/admin/Desktop/Code/inject/inject") { code, str in
-                    print(str)
-                    Inject.removeMachO(machoPath: "/Users/admin/Desktop/Code/inject/inject", cmdType: LC_Type.LOAD_DYLIB, backup: false, injectPath: "@executable_path/testMac/libtestinject.dylib") { result in
-                        Shell.run("otool -L /Users/admin/Desktop/Code/inject/inject") { code2, str2 in
-                            print(str2)
+                Shell.run("otool -L /Users/admin/Desktop/Code/inject/inject") { _, output in
+                    print(output)
+                    Inject.removeMachO(machoPath: "/Users/admin/Desktop/Code/inject/inject",
+                                       cmdType: LC_Type.LOAD_DYLIB,
+                                       backup: false,
+                                       injectPath: "@executable_path/testMac/libtestinject.dylib") { result in
+                        Shell.run("otool -L /Users/admin/Desktop/Code/inject/inject") { _, output in
+                            print(output)
                         }
                     }
                 }
             }
         }
-        
         // Do any additional setup after loading the view.
     }
 
@@ -33,7 +37,5 @@ class ViewController: NSViewController {
         // Update the view, if already loaded.
         }
     }
-
-
 }
 

--- a/Injection/InjectTest/ViewController.swift
+++ b/Injection/InjectTest/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: NSViewController {
                     Inject.removeMachO(machoPath: "/Users/admin/Desktop/Code/inject/inject",
                                        cmdType: LC_Type.LOAD_DYLIB,
                                        backup: false,
-                                       injectPath: "@executable_path/testMac/libtestinject.dylib") { result in
+                                       injectPath: "@executable_path/testMac/libtestinject.dylib") { _ in
                         Shell.run("otool -L /Users/admin/Desktop/Code/inject/inject") { _, output in
                             print(output)
                         }
@@ -38,4 +38,3 @@ class ViewController: NSViewController {
         }
     }
 }
-

--- a/Injection/Injection/BitType.swift
+++ b/Injection/Injection/BitType.swift
@@ -13,27 +13,22 @@ public enum BitType {
     case x86_fat
     case x64_fat
     case none
-    
-    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool)->()) {
+
+    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) ->  Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")
             handle(.x86_fat, false)
-            break
         case FAT_CIGAM_64, FAT_MAGIC_64:
             print("Please run 'lipo \(machoPath) -thin armv64 -output \(machoPath)_arm64' first")
             handle(.x64_fat, false)
-            break
         case MH_MAGIC, MH_CIGAM:
             handle(.x86, header.magic == MH_CIGAM)
-            break
         case MH_MAGIC_64, MH_CIGAM_64:
             handle(.x64, header.magic == MH_CIGAM_64)
-            break
         default:
             print("Unkonw machO header")
             handle(.none, false)
-            break
         }
     }
 }

--- a/Injection/Injection/BitType.swift
+++ b/Injection/Injection/BitType.swift
@@ -10,18 +10,18 @@ import Foundation
 public enum BitType {
     case x86
     case x64
-    case x86_fat
-    case x64_fat
+    case x86Fat
+    case x64Fat
     case none
 
     static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) -> Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")
-            handle(.x86_fat, false)
+            handle(.x86Fat, false)
         case FAT_CIGAM_64, FAT_MAGIC_64:
             print("Please run 'lipo \(machoPath) -thin armv64 -output \(machoPath)_arm64' first")
-            handle(.x64_fat, false)
+            handle(.x64Fat, false)
         case MH_MAGIC, MH_CIGAM:
             handle(.x86, header.magic == MH_CIGAM)
         case MH_MAGIC_64, MH_CIGAM_64:

--- a/Injection/Injection/BitType.swift
+++ b/Injection/Injection/BitType.swift
@@ -14,7 +14,7 @@ public enum BitType {
     case x64_fat
     case none
 
-    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) ->  Void) {
+    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) -> Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")

--- a/Injection/Injection/Command.swift
+++ b/Injection/Injection/Command.swift
@@ -54,7 +54,10 @@ public struct LoadCommand {
                     if isByteSwapped {
                         swap_dylib_command(&command, byteSwappedOrder)
                     }
-                    let curPath = String(data: binary, offset: offset, commandSize: Int(command.cmdsize), loadCommandString: command.dylib.name)
+                    let curPath = String(data: binary,
+                                         offset: offset,
+                                         commandSize: Int(command.cmdsize),
+                                         loadCommandString: command.dylib.name)
                     let curName = curPath.components(separatedBy: "/").last
                     if curName == dylibPath || curPath == dylibPath {
                         print("Load command already exists")
@@ -78,7 +81,10 @@ public struct LoadCommand {
                     if isByteSwapped {
                         swap_dylib_command(&command, byteSwappedOrder)
                     }
-                    let curPath = String(data: binary, offset: offset, commandSize: Int(command.cmdsize), loadCommandString: command.dylib.name)
+                    let curPath = String(data: binary,
+                                         offset: offset,
+                                         commandSize: Int(command.cmdsize),
+                                         loadCommandString: command.dylib.name)
                     let curName = curPath.components(separatedBy: "/").last
                     if curName == dylibPath || curPath == dylibPath {
                         print("Load command already exists")
@@ -186,14 +192,17 @@ public struct LoadCommand {
                     if isWeak {
                         header.ncmds -= 1
                         header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
-
                         let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
 
-                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size, with: newHeaderData)
-                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
-                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize), with: Data(count: Int(command.datasize)))
+                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size,
+                                                  with: newHeaderData)
+                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize),
+                                                  with: Data(count: Int(command.cmdsize)))
+                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize),
+                                                  with: Data(count: Int(command.datasize)))
                     } else {
-                        newbinary.replaceSubrange(offset..<offset + 4, with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                        newbinary.replaceSubrange(offset..<offset + 4,
+                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -208,14 +217,17 @@ public struct LoadCommand {
                     if isWeak {
                         header.sizeofcmds -= 1
                         header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
-
                         let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
 
-                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size, with: newHeaderData)
-                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
-                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize), with: Data(count: Int(command.datasize)))
+                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size,
+                                                  with: newHeaderData)
+                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize),
+                                                  with: Data(count: Int(command.cmdsize)))
+                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize),
+                                                  with: Data(count: Int(command.datasize)))
                     } else {
-                        newbinary.replaceSubrange(offset..<offset + 4, with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                        newbinary.replaceSubrange(offset..<offset + 4,
+                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -234,7 +246,8 @@ public struct LoadCommand {
             var header = newbinary.extract(mach_header.self)
             if (header.flags & UInt32(MH_PIE)) != 0 {
                 header.flags &= 0xFFDFFFFF
-                newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size, with: Data(bytes: &header, count: MemoryLayout<mach_header>.size))
+                newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size,
+                                          with: Data(bytes: &header, count: MemoryLayout<mach_header>.size))
             } else {
                 handle(nil)
                 return
@@ -243,7 +256,8 @@ public struct LoadCommand {
             var header = binary.extract(mach_header_64.self)
             if (header.flags & UInt32(MH_PIE)) != 0 {
                 header.flags &= 0xFFDFFFFF
-                newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size, with: Data(bytes: &header, count: MemoryLayout<mach_header_64>.size))
+                newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size,
+                                          with: Data(bytes: &header, count: MemoryLayout<mach_header_64>.size))
             } else {
                 handle(nil)
                 return
@@ -276,7 +290,10 @@ public struct LoadCommand {
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
                     let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
-                    if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
+                    if String.init(data: newbinary,
+                                   offset: offset,
+                                   commandSize: Int(dylib_command.cmdsize),
+                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 
@@ -300,7 +317,10 @@ public struct LoadCommand {
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
                     let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
-                    if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
+                    if String.init(data: newbinary,
+                                   offset: offset,
+                                   commandSize: Int(dylib_command.cmdsize),
+                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 

--- a/Injection/Injection/Command.swift
+++ b/Injection/Injection/Command.swift
@@ -11,20 +11,20 @@ import MachO
 let byteSwappedOrder = NXByteOrder(rawValue: 0)
 
 public enum LCType: String {
-    case REEXPORT_DYLIB = "LC_REEXPORT_DYLIB"
-    case LOAD_WEAK_DYLIB = "LC_LOAD_WEAK_DYLIB"
-    case LOAD_UPWARD_DYLIB = "LC_LOAD_UPWARD_DYLIB"
-    case LOAD_DYLIB = "LC_LOAD_DYLIB"
+    case reexportDylib = "LC_REEXPORT_DYLIB"
+    case loadWeakDylib = "LC_LOAD_WEAK_DYLIB"
+    case loadUpwardDylib = "LC_LOAD_UPWARD_DYLIB"
+    case loadDylib = "LC_LOAD_DYLIB"
 
     static func get(_ type: String) -> UInt32 {
         switch type {
-        case LCType.REEXPORT_DYLIB.rawValue:
+        case LCType.reexportDylib.rawValue:
             return LC_REEXPORT_DYLIB
-        case LCType.LOAD_WEAK_DYLIB.rawValue:
+        case LCType.loadWeakDylib.rawValue:
             return LC_LOAD_WEAK_DYLIB
-        case LCType.LOAD_UPWARD_DYLIB.rawValue:
+        case LCType.loadUpwardDylib.rawValue:
             return LC_LOAD_UPWARD_DYLIB
-        case LCType.LOAD_DYLIB.rawValue:
+        case LCType.loadDylib.rawValue:
             return UInt32(LC_LOAD_DYLIB)
         default:
             return 0
@@ -179,7 +179,7 @@ public struct LoadCommand {
             return
         }
         var newbinary = binary
-        var OP_SOFT_STRIP = 0x00001337
+        var opSoftStrip = 0x00001337
         if type == .x86 {
             var header = newbinary.extract(mach_header.self)
             var offset = MemoryLayout.size(ofValue: header)
@@ -200,7 +200,7 @@ public struct LoadCommand {
                                                   with: Data(count: Int(command.datasize)))
                     } else {
                         newbinary.replaceSubrange(offset..<offset + 4,
-                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                                                  with: Data(bytes: &opSoftStrip, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -225,7 +225,7 @@ public struct LoadCommand {
                                                   with: Data(count: Int(command.datasize)))
                     } else {
                         newbinary.replaceSubrange(offset..<offset + 4,
-                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                                                  with: Data(bytes: &opSoftStrip, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)

--- a/Injection/Injection/Command.swift
+++ b/Injection/Injection/Command.swift
@@ -10,7 +10,7 @@ import MachO
 
 let byteSwappedOrder = NXByteOrder(rawValue: 0)
 
-public enum LC_Type: String {
+public enum LCType: String {
     case REEXPORT_DYLIB = "LC_REEXPORT_DYLIB"
     case LOAD_WEAK_DYLIB = "LC_LOAD_WEAK_DYLIB"
     case LOAD_UPWARD_DYLIB = "LC_LOAD_UPWARD_DYLIB"
@@ -18,13 +18,13 @@ public enum LC_Type: String {
     
     static func get(_ type: String) -> UInt32 {
         switch type {
-        case LC_Type.REEXPORT_DYLIB.rawValue:
+        case LCType.REEXPORT_DYLIB.rawValue:
             return LC_REEXPORT_DYLIB
-        case LC_Type.LOAD_WEAK_DYLIB.rawValue:
+        case LCType.LOAD_WEAK_DYLIB.rawValue:
             return LC_LOAD_WEAK_DYLIB
-        case LC_Type.LOAD_UPWARD_DYLIB.rawValue:
+        case LCType.LOAD_UPWARD_DYLIB.rawValue:
             return LC_LOAD_UPWARD_DYLIB
-        case LC_Type.LOAD_DYLIB.rawValue:
+        case LCType.LOAD_DYLIB.rawValue:
             return UInt32(LC_LOAD_DYLIB)
         default:
             return 0
@@ -64,7 +64,6 @@ public struct LoadCommand {
                         handle(false)
                         return
                     }
-                    break
                 default:
                     break
                 }
@@ -91,7 +90,6 @@ public struct LoadCommand {
                         handle(false)
                         return
                     }
-                    break
                 default:
                     break
                 }

--- a/Injection/Injection/Command.swift
+++ b/Injection/Injection/Command.swift
@@ -33,8 +33,11 @@ public enum LC_Type: String {
 }
 
 public struct LoadCommand {
-    
-    public static func couldInjectLoadCommand(binary: Data, dylibPath: String, type:BitType, isByteSwapped: Bool, handle: (Bool)->()) {
+    public static func couldInjectLoadCommand(binary: Data,
+                                              dylibPath: String,
+                                              type: BitType,
+                                              isByteSwapped: Bool,
+                                              handle: (Bool) -> Void) {
         if type == .x64_fat || type == .x86_fat || type == .none {
             handle(false)
             return
@@ -91,14 +94,19 @@ public struct LoadCommand {
         }
         handle(true)
     }
-    
-    public static func inject(binary: Data, dylibPath: String, cmd: UInt32, type:BitType, canInject: Bool, handle: (Data?)->()) {
+
+    public static func inject(binary: Data,
+                              dylibPath: String,
+                              cmd: UInt32,
+                              type: BitType,
+                              canInject: Bool,
+                              handle: (Data?) -> Void) {
         if canInject {
             var newbinary = binary
             let length = MemoryLayout<dylib_command>.size + dylibPath.lengthOfBytes(using: String.Encoding.utf8)
             let padding = (8 - (length % 8))
             let cmdsize = length+padding
-            
+
             var start = 0
             var end = cmdsize
             var subData: Data
@@ -109,8 +117,11 @@ public struct LoadCommand {
                 start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header>.size)
                 end += start
                 subData = newbinary[start..<end]
-                
-                var newheader = mach_header(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds+1, sizeofcmds: header.sizeofcmds+UInt32(cmdsize), flags: header.flags)
+
+                var newheader = header
+                newheader.ncmds += 1
+                newheader.sizeofcmds += UInt32(cmdsize)
+
                 newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header>.size)
                 machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header>.size))!
             } else {
@@ -118,22 +129,30 @@ public struct LoadCommand {
                 start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header_64>.size)
                 end += start
                 subData = newbinary[start..<end]
-                
-                var newheader = mach_header_64(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds+1, sizeofcmds: header.sizeofcmds+UInt32(cmdsize), flags: header.flags, reserved: header.reserved)
+
+                var newheader = header
+                newheader.ncmds += 1
+                newheader.sizeofcmds += UInt32(cmdsize)
+
                 newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
                 machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
             }
-            
+
             let d = String(data: subData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
             if d != "" && d != nil {
                 print("cannot inject payload into \(dylibPath) because there is no room")
                 handle(nil)
                 return
             }
-            
-            let dy = dylib(name: lc_str(offset: UInt32(MemoryLayout<dylib_command>.size)), timestamp: 2, current_version: 0, compatibility_version: 0)
-            var command = dylib_command(cmd: cmd, cmdsize: UInt32(cmdsize), dylib: dy)
-            
+
+            let dy = dylib(name: lc_str(offset: UInt32(MemoryLayout<dylib_command>.size)),
+                           timestamp: 2,
+                           current_version: 0,
+                           compatibility_version: 0)
+            var command = dylib_command(cmd: cmd,
+                                        cmdsize: UInt32(cmdsize),
+                                        dylib: dy)
+
             var zero: UInt = 0
             var commandData = Data()
             commandData.append(Data(bytes: &command, count: MemoryLayout<dylib_command>.size))
@@ -144,14 +163,17 @@ public struct LoadCommand {
             newbinary.replaceSubrange(subrange, with: commandData)
             
             newbinary.replaceSubrange(machoRange, with: newHeaderData)
-            
+
             handle(newbinary)
         } else {
             handle(nil)
         }
     }
-    
-    public static func removeSignature(binary: Data, type:BitType, isWeak: Bool, handle: (Data?)->()) {
+
+    public static func removeSignature(binary: Data,
+                                       type: BitType,
+                                       isWeak: Bool,
+                                       handle: (Data?) -> Void) {
         if type == .x64_fat || type == .x86_fat || type == .none {
             handle(nil)
             return
@@ -201,8 +223,8 @@ public struct LoadCommand {
         }
         handle(newbinary)
     }
-    
-    public static func removeASLR(binary: Data, type:BitType, handle: (Data?)->()) {
+
+    public static func removeASLR(binary: Data, type: BitType, handle: (Data?) -> Void) {
         if type == .x64_fat || type == .x86_fat || type == .none {
             handle(nil)
             return
@@ -229,8 +251,12 @@ public struct LoadCommand {
         }
         handle(newbinary)
     }
-    
-    public static func remove(binary: Data, dylibPath: String, cmd: UInt32, type:BitType, handle: (Data?)->()) {
+
+    public static func remove(binary: Data,
+                              dylibPath: String,
+                              cmd: UInt32,
+                              type: BitType,
+                              handle: (Data?) -> Void) {
         if type == .x64_fat || type == .x86_fat || type == .none {
             handle(nil)
             return
@@ -241,7 +267,7 @@ public struct LoadCommand {
         var start: Int?
         var size: Int?
         var end: Int?
-        
+
         if type == .x86 {
             var newheader: mach_header
             let header = newbinary.extract(mach_header.self)
@@ -254,7 +280,11 @@ public struct LoadCommand {
                     if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
-                        newheader = mach_header(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds-1, sizeofcmds: header.sizeofcmds-UInt32(dylib_command.cmdsize), flags: header.flags)
+
+                        newheader = header
+                        newheader.ncmds -= 1
+                        newheader.sizeofcmds -= UInt32(dylib_command.cmdsize)
+
                         newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header>.size)
                         machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header>.size))!
                     }
@@ -276,7 +306,11 @@ public struct LoadCommand {
                     if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
-                        newheader = mach_header_64(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds-1, sizeofcmds: header.sizeofcmds-UInt32(dylib_command.cmdsize), flags: header.flags, reserved: header.reserved)
+
+                        newheader = header
+                        newheader.ncmds -= 1
+                        newheader.sizeofcmds -= UInt32(dylib_command.cmdsize)
+
                         newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
                         machoRange = Range(NSRange(location: 0, length: MemoryLayout<mach_header_64>.size))!
                     }
@@ -287,7 +321,7 @@ public struct LoadCommand {
             }
             end = offset
         }
-        
+
         if let s = start, let e = end, let si = size, let mr = machoRange, let nh = newHeaderData {
             let subrangeNew = Range(NSRange(location: s+si, length: e-s-si))!
             let subrangeOld = Range(NSRange(location: s, length: e-s))!
@@ -299,7 +333,7 @@ public struct LoadCommand {
             newbinary.replaceSubrange(subrangeOld, with: commandData)
             newbinary.replaceSubrange(mr, with: nh)
         }
-        
+
         handle(newbinary)
     }
 }

--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -11,7 +11,9 @@ extension Data {
     func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
         let data = self[offset..<offset + MemoryLayout<T>.size]
         return data.withUnsafeBytes { dataBytes in
-            dataBytes.baseAddress!.assumingMemoryBound(to: UInt8.self).withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
+            dataBytes.baseAddress!
+                .assumingMemoryBound(to: UInt8.self)
+                .withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
                 return p.pointee
             }
         }

--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -19,22 +19,12 @@ extension Data {
 }
 
 extension String {
-    init(_ rawCString: (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)) {
-        var rawCString = rawCString
-        let rawCStringSize = MemoryLayout.size(ofValue: rawCString)
-        let string = withUnsafePointer(to: &rawCString) { (pointer) -> String in
-            return pointer.withMemoryRebound(to: UInt8.self, capacity: rawCStringSize, {
-                return String(cString: $0)
-            })
-        }
-        self.init(string)
-    }
-    
     init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
         let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)], encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        self = String(data: data[stringOffset..<(stringOffset + length)],
+                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
     }
 }
 

--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -39,7 +39,7 @@ extension String {
 }
 
 extension FileManager {
-    static func open(machoPath: String, backup: Bool, handle: (Data?)->()) {
+    static func open(machoPath: String, backup: Bool, handle: (Data?) -> Void) {
         do {
             if FileManager.default.fileExists(atPath: machoPath) {
                 if backup {

--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -13,8 +13,8 @@ extension Data {
         return data.withUnsafeBytes { dataBytes in
             dataBytes.baseAddress!
                 .assumingMemoryBound(to: UInt8.self)
-                .withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
-                return p.pointee
+                .withMemoryRebound(to: T.self, capacity: 1) { (pointer) -> T in
+                return pointer.pointee
             }
         }
     }

--- a/Injection/Injection/Inject.swift
+++ b/Injection/Injection/Inject.swift
@@ -95,12 +95,10 @@ public struct Inject {
                     let fileList = try FileManager.default.contentsOfDirectory(atPath: payload)
                     var machoPath = ""
                     var appPath = ""
-                    for item in fileList {
-                        if item.hasSuffix(".app") {
-                            appPath = payload + "/\(item)"
-                            machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
-                            break
-                        }
+                    for item in fileList where item.hasSuffix(".app") {
+                        appPath = payload + "/\(item)"
+                        machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
+                        break
                     }
 
                     try FileManager.default.createDirectory(atPath: "\(appPath)/Inject/",
@@ -148,12 +146,10 @@ public struct Inject {
                     let fileList = try FileManager.default.contentsOfDirectory(atPath: payload)
                     var machoPath = ""
                     var appPath = ""
-                    for item in fileList {
-                        if item.hasSuffix(".app") {
-                            appPath = payload + "/\(item)"
-                            machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
-                            break
-                        }
+                    for item in fileList where item.hasSuffix(".app") {
+                        appPath = payload + "/\(item)"
+                        machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
+                        break
                     }
                     removeMachO(machoPath: machoPath,
                                 cmdType: cmdType,

--- a/Injection/Injection/Inject.swift
+++ b/Injection/Injection/Inject.swift
@@ -11,7 +11,7 @@ public struct Inject {
     public static func injectIPA(ipaPath: String,
                                  cmdType: LCType,
                                  injectPath: String,
-                                 finishHandle:(Bool) -> Void) {
+                                 finishHandle: (Bool) -> Void) {
         var result = false
         var injectFilePath = "."
         if injectPath.hasPrefix("@") {
@@ -30,7 +30,7 @@ public struct Inject {
         var iName = ""
         var injectPathNew = ""
         let components = injectPath.components(separatedBy: "/")
-        
+
         if injectPath.hasSuffix(".framework") {
             iName = injectFilePath.components(separatedBy: "/").last!
             iPath = injectFilePath
@@ -185,13 +185,13 @@ public struct Inject {
                                    cmdType: LCType,
                                    backup: Bool,
                                    injectPath: String,
-                                   finishHandle:(Bool) -> Void) {
+                                   finishHandle: (Bool) -> Void) {
         let cmdType = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in
             if let binary = data {
                 let fatHeader = binary.extract(fat_header.self)
-                BitType.checkType(machoPath: machoPath, header: fatHeader) { type, isByteSwapped in
+                BitType.checkType(machoPath: machoPath, header: fatHeader) { type, _ in
                     if injectPath.count > 0 {
                         LoadCommand.remove(binary: binary,
                                            dylibPath: injectPath,
@@ -215,7 +215,7 @@ public struct Inject {
                                    cmdType: LCType,
                                    backup: Bool,
                                    injectPath: String,
-                                   finishHandle:(Bool) -> Void) {
+                                   finishHandle: (Bool) -> Void) {
         let cmdType = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in

--- a/Injection/Injection/Inject.swift
+++ b/Injection/Injection/Inject.swift
@@ -103,10 +103,16 @@ public struct Inject {
                         }
                     }
 
-                    try FileManager.default.createDirectory(atPath: "\(appPath)/Inject/", withIntermediateDirectories: true, attributes: nil)
-                    try FileManager.default.moveItem(atPath: iPath, toPath: "\(appPath)/Inject/\(iName)")
+                    try FileManager.default.createDirectory(atPath: "\(appPath)/Inject/",
+                                                            withIntermediateDirectories: true,
+                                                            attributes: nil)
+                    try FileManager.default.moveItem(atPath: iPath,
+                                                     toPath: "\(appPath)/Inject/\(iName)")
 
-                    injectMachO(machoPath: machoPath, cmdType: cmdType, backup: false, injectPath: injectPathNew) { success in
+                    injectMachO(machoPath: machoPath,
+                                cmdType: cmdType,
+                                backup: false,
+                                injectPath: injectPathNew) { success in
                         if success {
                             Shell.run("zip -r \(ipaPath) \(payload)") { t2, o2 in
                                 if t2 == 0 {
@@ -149,7 +155,10 @@ public struct Inject {
                             break
                         }
                     }
-                    removeMachO(machoPath: machoPath, cmdType: cmdType, backup: false, injectPath: injectPath) { success in
+                    removeMachO(machoPath: machoPath,
+                                cmdType: cmdType,
+                                backup: false,
+                                injectPath: injectPath) { success in
                         if success {
                             Shell.run("zip -r \(ipaPath) \(payload)") { t2, o2 in
                                 if t2 == 0 {
@@ -214,9 +223,19 @@ public struct Inject {
                 let fh = binary.extract(fat_header.self)
                 BitType.checkType(machoPath: machoPath, header: fh) { type, isByteSwapped  in
                     if injectPath.count > 0 {
-                        LoadCommand.couldInjectLoadCommand(binary: binary, dylibPath: injectPath, type: type, isByteSwapped: isByteSwapped) { canInject in
-                            LoadCommand.inject(binary: binary, dylibPath: injectPath, cmd: cmd_type, type: type, canInject: canInject) { newBinary in
-                                result = Inject.writeFile(newBinary: newBinary, machoPath: machoPath, successTitle: "Inject \(injectPath) Finish", failTitle: "Inject \(injectPath) failed")
+                        LoadCommand.couldInjectLoadCommand(binary: binary,
+                                                           dylibPath: injectPath,
+                                                           type: type,
+                                                           isByteSwapped: isByteSwapped) { canInject in
+                            LoadCommand.inject(binary: binary,
+                                               dylibPath: injectPath,
+                                               cmd: cmd_type,
+                                               type: type,
+                                               canInject: canInject) { newBinary in
+                                result = Inject.writeFile(newBinary: newBinary,
+                                                          machoPath: machoPath,
+                                                          successTitle: "Inject \(injectPath) Finish",
+                                                          failTitle: "Inject \(injectPath) failed")
                             }
                         }
                     } else {

--- a/Injection/Injection/Inject.swift
+++ b/Injection/Injection/Inject.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct Inject {
     public static func injectIPA(ipaPath: String,
-                                 cmdType: LC_Type,
+                                 cmdType: LCType,
                                  injectPath: String,
                                  finishHandle:(Bool) -> Void) {
         var result = false
@@ -88,8 +88,8 @@ public struct Inject {
         }
 
         let targetUrl = "."
-        Shell.run("unzip -o \(ipaPath) -d \(targetUrl)") { t1, o1 in
-            if t1 == 0 {
+        Shell.run("unzip -o \(ipaPath) -d \(targetUrl)") { status, output in
+            if status == 0 {
                 let payload = targetUrl+"/Payload"
                 do {
                     let fileList = try FileManager.default.contentsOfDirectory(atPath: payload)
@@ -114,35 +114,35 @@ public struct Inject {
                                 backup: false,
                                 injectPath: injectPathNew) { success in
                         if success {
-                            Shell.run("zip -r \(ipaPath) \(payload)") { t2, o2 in
-                                if t2 == 0 {
+                            Shell.run("zip -r \(ipaPath) \(payload)") { status, output in
+                                if status == 0 {
                                     print("Inject \(injectPath) finish, new IPA file is \(ipaPath)")
                                     result = true
                                 } else {
-                                    print("\(o2)")
+                                    print("\(output)")
                                 }
                             }
                         }
                     }
                     try FileManager.default.removeItem(atPath: payload)
-                } catch let e {
-                    print("\(e)")
+                } catch let error {
+                    print("\(error)")
                 }
             } else {
-                print("\(o1)")
+                print("\(output)")
             }
         }
         finishHandle(result)
     }
 
     public static func removeIPA(ipaPath: String,
-                                 cmdType: LC_Type,
+                                 cmdType: LCType,
                                  injectPath: String,
                                  finishHandle: (Bool) -> Void) {
         var result = false
         let targetUrl = "."
-        Shell.run("unzip -o \(ipaPath) -d \(targetUrl)") { t1, o1 in
-            if t1 == 0 {
+        Shell.run("unzip -o \(ipaPath) -d \(targetUrl)") { status, output in
+            if status == 0 {
                 let payload = targetUrl+"/Payload"
                 do {
                     let fileList = try FileManager.default.contentsOfDirectory(atPath: payload)
@@ -160,38 +160,38 @@ public struct Inject {
                                 backup: false,
                                 injectPath: injectPath) { success in
                         if success {
-                            Shell.run("zip -r \(ipaPath) \(payload)") { t2, o2 in
-                                if t2 == 0 {
+                            Shell.run("zip -r \(ipaPath) \(payload)") { status, output in
+                                if status == 0 {
                                     print("Remove \(injectPath) finish, new IPA file is \(ipaPath)")
                                     result = true
                                 } else {
-                                    print("\(o2)")
+                                    print("\(output)")
                                 }
                             }
                         }
                     }
                     try FileManager.default.removeItem(atPath: payload)
-                } catch let e {
-                    print("\(e)")
+                } catch let error {
+                    print("\(error)")
                 }
             } else {
-                print("\(o1)")
+                print("\(output)")
             }
         }
         finishHandle(result)
     }
 
     public static func removeMachO(machoPath: String,
-                                   cmdType: LC_Type,
+                                   cmdType: LCType,
                                    backup: Bool,
                                    injectPath: String,
                                    finishHandle:(Bool) -> Void) {
-        let cmd_type = LC_Type.get(cmdType.rawValue)
+        let cmd_type = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in
             if let binary = data {
-                let fh = binary.extract(fat_header.self)
-                BitType.checkType(machoPath: machoPath, header: fh) { type, isByteSwapped  in
+                let fatHeader = binary.extract(fat_header.self)
+                BitType.checkType(machoPath: machoPath, header: fatHeader) { type, isByteSwapped in
                     if injectPath.count > 0 {
                         LoadCommand.remove(binary: binary,
                                            dylibPath: injectPath,
@@ -212,16 +212,16 @@ public struct Inject {
     }
 
     public static func injectMachO(machoPath: String,
-                                   cmdType: LC_Type,
+                                   cmdType: LCType,
                                    backup: Bool,
                                    injectPath: String,
                                    finishHandle:(Bool) -> Void) {
-        let cmd_type = LC_Type.get(cmdType.rawValue)
+        let cmd_type = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in
             if let binary = data {
-                let fh = binary.extract(fat_header.self)
-                BitType.checkType(machoPath: machoPath, header: fh) { type, isByteSwapped  in
+                let fatHeader = binary.extract(fat_header.self)
+                BitType.checkType(machoPath: machoPath, header: fatHeader) { type, isByteSwapped in
                     if injectPath.count > 0 {
                         LoadCommand.couldInjectLoadCommand(binary: binary,
                                                            dylibPath: injectPath,
@@ -251,13 +251,13 @@ public struct Inject {
                                   machoPath: String,
                                   successTitle: String,
                                   failTitle: String) -> Bool {
-        if let b = newBinary {
+        if let newBinary = newBinary {
             do {
-                try b.write(to: URL(fileURLWithPath: machoPath))
+                try newBinary.write(to: URL(fileURLWithPath: machoPath))
                 print(successTitle)
                 return true
-            } catch let err {
-                print(err)
+            } catch let error {
+                print(error)
             }
         }
         print(failTitle)

--- a/Injection/Injection/Inject.swift
+++ b/Injection/Injection/Inject.swift
@@ -186,7 +186,7 @@ public struct Inject {
                                    backup: Bool,
                                    injectPath: String,
                                    finishHandle:(Bool) -> Void) {
-        let cmd_type = LCType.get(cmdType.rawValue)
+        let cmdType = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in
             if let binary = data {
@@ -195,7 +195,7 @@ public struct Inject {
                     if injectPath.count > 0 {
                         LoadCommand.remove(binary: binary,
                                            dylibPath: injectPath,
-                                           cmd: cmd_type,
+                                           cmd: cmdType,
                                            type: type) { newBinary in
                             result = Inject.writeFile(newBinary: newBinary,
                                                       machoPath: machoPath,
@@ -216,7 +216,7 @@ public struct Inject {
                                    backup: Bool,
                                    injectPath: String,
                                    finishHandle:(Bool) -> Void) {
-        let cmd_type = LCType.get(cmdType.rawValue)
+        let cmdType = LCType.get(cmdType.rawValue)
         var result = false
         FileManager.open(machoPath: machoPath, backup: backup) { data in
             if let binary = data {
@@ -229,7 +229,7 @@ public struct Inject {
                                                            isByteSwapped: isByteSwapped) { canInject in
                             LoadCommand.inject(binary: binary,
                                                dylibPath: injectPath,
-                                               cmd: cmd_type,
+                                               cmd: cmdType,
                                                type: type,
                                                canInject: canInject) { newBinary in
                                 result = Inject.writeFile(newBinary: newBinary,

--- a/Injection/Injection/Shell.swift
+++ b/Injection/Injection/Shell.swift
@@ -12,15 +12,15 @@ public struct Shell {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = pipe
-        
+
         task.launch()
-        
+
         let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: String.Encoding.utf8)
-        
+
         task.waitUntilExit()
         handle(task.terminationStatus, output ?? "")
     }

--- a/Injection/Injection/Shell.swift
+++ b/Injection/Injection/Shell.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct Shell {
-    public static func run(_ command: String, handle:(Int32, String) -> Void) {
+    public static func run(_ command: String, handle: (Int32, String) -> Void) {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]

--- a/Injection/Injection/Shell.swift
+++ b/Injection/Injection/Shell.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct Shell {
-    public static func run(_ command: String, handle:(Int32, String)->()) {
+    public static func run(_ command: String, handle:(Int32, String) -> Void) {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .target(
             name: "inject",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -8,27 +8,34 @@ let package = Package(
     products: [
         .executable(
             name: "inject",
-            targets: ["inject"]),
+            targets: ["inject"]
+        ),
         .library(
             name: "Injection",
-            targets: ["injection"]),
+            targets: ["injection"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "inject",
-            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser"),]),
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
         .target(
             name: "injection",
             dependencies: [],
-            path: "Injection/Injection"),
+            path: "Injection/Injection"
+        ),
         .testTarget(
             name: "injectTests",
-            dependencies: ["inject"]),
+            dependencies: ["inject"]
+        )
     ]
 )

--- a/Sources/inject/BitType.swift
+++ b/Sources/inject/BitType.swift
@@ -13,27 +13,22 @@ public enum BitType {
     case x86_fat
     case x64_fat
     case none
-    
-    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool)->()) {
+
+    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) ->  Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")
             handle(.x86_fat, false)
-            break
         case FAT_CIGAM_64, FAT_MAGIC_64:
             print("Please run 'lipo \(machoPath) -thin armv64 -output \(machoPath)_arm64' first")
             handle(.x64_fat, false)
-            break
         case MH_MAGIC, MH_CIGAM:
             handle(.x86, header.magic == MH_CIGAM)
-            break
         case MH_MAGIC_64, MH_CIGAM_64:
             handle(.x64, header.magic == MH_CIGAM_64)
-            break
         default:
             print("Unkonw machO header")
             handle(.none, false)
-            break
         }
     }
 }

--- a/Sources/inject/BitType.swift
+++ b/Sources/inject/BitType.swift
@@ -10,18 +10,18 @@ import Foundation
 public enum BitType {
     case x86
     case x64
-    case x86_fat
-    case x64_fat
+    case x86Fat
+    case x64Fat
     case none
 
     static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) -> Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")
-            handle(.x86_fat, false)
+            handle(.x86Fat, false)
         case FAT_CIGAM_64, FAT_MAGIC_64:
             print("Please run 'lipo \(machoPath) -thin armv64 -output \(machoPath)_arm64' first")
-            handle(.x64_fat, false)
+            handle(.x64Fat, false)
         case MH_MAGIC, MH_CIGAM:
             handle(.x86, header.magic == MH_CIGAM)
         case MH_MAGIC_64, MH_CIGAM_64:

--- a/Sources/inject/BitType.swift
+++ b/Sources/inject/BitType.swift
@@ -14,7 +14,7 @@ public enum BitType {
     case x64_fat
     case none
 
-    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) ->  Void) {
+    static func checkType(machoPath: String, header: fat_header, handle: (BitType, Bool) -> Void) {
         switch header.magic {
         case FAT_CIGAM, FAT_MAGIC:
             print("Please run 'lipo \(machoPath) -thin armv7 -output \(machoPath)_armv7' first")

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -11,20 +11,20 @@ import MachO
 let byteSwappedOrder = NXByteOrder(rawValue: 0)
 
 public enum LCType: String {
-    case REEXPORT_DYLIB = "LC_REEXPORT_DYLIB"
-    case LOAD_WEAK_DYLIB = "LC_LOAD_WEAK_DYLIB"
-    case LOAD_UPWARD_DYLIB = "LC_LOAD_UPWARD_DYLIB"
-    case LOAD_DYLIB = "LC_LOAD_DYLIB"
+    case reexportDylib = "LC_REEXPORT_DYLIB"
+    case loadWeakDylib = "LC_LOAD_WEAK_DYLIB"
+    case loadUpwardDylib = "LC_LOAD_UPWARD_DYLIB"
+    case loadDylib = "LC_LOAD_DYLIB"
 
     static func get(_ type: String) -> UInt32 {
         switch type {
-        case LCType.REEXPORT_DYLIB.rawValue:
+        case LCType.reexportDylib.rawValue:
             return LC_REEXPORT_DYLIB
-        case LCType.LOAD_WEAK_DYLIB.rawValue:
+        case LCType.loadWeakDylib.rawValue:
             return LC_LOAD_WEAK_DYLIB
-        case LCType.LOAD_UPWARD_DYLIB.rawValue:
+        case LCType.loadUpwardDylib.rawValue:
             return LC_LOAD_UPWARD_DYLIB
-        case LCType.LOAD_DYLIB.rawValue:
+        case LCType.loadDylib.rawValue:
             return UInt32(LC_LOAD_DYLIB)
         default:
             return 0
@@ -179,7 +179,7 @@ public struct LoadCommand {
             return
         }
         var newbinary = binary
-        var OP_SOFT_STRIP = 0x00001337
+        var opSoftStrip = 0x00001337
         if type == .x86 {
             var header = newbinary.extract(mach_header.self)
             var offset = MemoryLayout.size(ofValue: header)
@@ -200,7 +200,7 @@ public struct LoadCommand {
                                                   with: Data(count: Int(command.datasize)))
                     } else {
                         newbinary.replaceSubrange(offset..<offset + 4,
-                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                                                  with: Data(bytes: &opSoftStrip, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -225,7 +225,7 @@ public struct LoadCommand {
                                                   with: Data(count: Int(command.datasize)))
                     } else {
                         newbinary.replaceSubrange(offset..<offset + 4,
-                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                                                  with: Data(bytes: &opSoftStrip, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -15,7 +15,7 @@ public enum LC_Type: String {
     case LOAD_WEAK_DYLIB = "LC_LOAD_WEAK_DYLIB"
     case LOAD_UPWARD_DYLIB = "LC_LOAD_UPWARD_DYLIB"
     case LOAD_DYLIB = "LC_LOAD_DYLIB"
-    
+
     static func get(_ type: String) -> UInt32 {
         switch type {
         case LC_Type.REEXPORT_DYLIB.rawValue:
@@ -158,10 +158,10 @@ public struct LoadCommand {
             commandData.append(Data(bytes: &command, count: MemoryLayout<dylib_command>.size))
             commandData.append(dylibPath.data(using: String.Encoding.ascii) ?? Data())
             commandData.append(Data(bytes: &zero, count: padding))
-            
+
             let subrange = Range(NSRange(location: start, length: commandData.count))!
             newbinary.replaceSubrange(subrange, with: commandData)
-            
+
             newbinary.replaceSubrange(machoRange, with: newHeaderData)
 
             handle(newbinary)

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -113,28 +113,26 @@ public struct LoadCommand {
             var newHeaderData: Data
             var machoRange: Range<Data.Index>
             if type == .x86 {
-                let header = binary.extract(mach_header.self)
-                start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header>.size)
+                var header = binary.extract(mach_header.self)
+                start = Int(header.sizeofcmds) + Int(MemoryLayout<mach_header>.size)
                 end += start
                 subData = newbinary[start..<end]
 
-                var newheader = header
-                newheader.ncmds += 1
-                newheader.sizeofcmds += UInt32(cmdsize)
+                header.ncmds += 1
+                header.sizeofcmds += UInt32(cmdsize)
 
-                newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header>.size)
+                newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
                 machoRange = 0..<MemoryLayout<mach_header>.size
             } else {
-                let header = binary.extract(mach_header_64.self)
-                start = Int(header.sizeofcmds)+Int(MemoryLayout<mach_header_64>.size)
+                var header = binary.extract(mach_header_64.self)
+                start = Int(header.sizeofcmds) + Int(MemoryLayout<mach_header_64>.size)
                 end += start
                 subData = newbinary[start..<end]
 
-                var newheader = header
-                newheader.ncmds += 1
-                newheader.sizeofcmds += UInt32(cmdsize)
+                header.ncmds += 1
+                header.sizeofcmds += UInt32(cmdsize)
 
-                newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
+                newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
                 machoRange = 0..<MemoryLayout<mach_header_64>.size
             }
 
@@ -179,15 +177,16 @@ public struct LoadCommand {
         var newbinary = binary
         var OP_SOFT_STRIP = 0x00001337
         if type == .x86 {
-            let header = newbinary.extract(mach_header.self)
+            var header = newbinary.extract(mach_header.self)
             var offset = MemoryLayout.size(ofValue: header)
             for _ in 0..<header.ncmds {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
                 if loadCommand.cmd == UInt32(LC_CODE_SIGNATURE) {
                     let command = binary.extract(linkedit_data_command.self, offset: offset)
                     if isWeak {
-                        var newheader = mach_header(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds-1, sizeofcmds: header.sizeofcmds-UInt32(MemoryLayout<linkedit_data_command>.size), flags: header.flags)
-                        let newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header>.size)
+                        header.ncmds -= 1
+                        header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
+                        let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
 
                         newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size, with: newHeaderData)
                         newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
@@ -199,15 +198,16 @@ public struct LoadCommand {
                 offset += Int(loadCommand.cmdsize)
             }
         } else {
-            let header = binary.extract(mach_header_64.self)
+            var header = binary.extract(mach_header_64.self)
             var offset = MemoryLayout.size(ofValue: header)
             for _ in 0..<header.ncmds {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
                 if loadCommand.cmd == UInt32(LC_CODE_SIGNATURE) {
                     let command = binary.extract(linkedit_data_command.self, offset: offset)
                     if isWeak {
-                        var newheader = mach_header_64(magic: header.magic, cputype: header.cputype, cpusubtype: header.cpusubtype, filetype: header.filetype, ncmds: header.ncmds-1, sizeofcmds: header.sizeofcmds-UInt32(MemoryLayout<linkedit_data_command>.size), flags: header.flags, reserved: header.reserved)
-                        let newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
+                        header.ncmds -= 1
+                        header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
+                        let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
 
                         newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size, with: newHeaderData)
                         newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
@@ -267,8 +267,7 @@ public struct LoadCommand {
         var end: Int?
 
         if type == .x86 {
-            var newheader: mach_header
-            let header = newbinary.extract(mach_header.self)
+            var header = newbinary.extract(mach_header.self)
             var offset = MemoryLayout.size(ofValue: header)
             for _ in 0..<header.ncmds {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
@@ -279,11 +278,10 @@ public struct LoadCommand {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 
-                        newheader = header
-                        newheader.ncmds -= 1
-                        newheader.sizeofcmds -= UInt32(dylib_command.cmdsize)
+                        header.ncmds -= 1
+                        header.sizeofcmds -= UInt32(dylib_command.cmdsize)
 
-                        newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header>.size)
+                        newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
                         machoRange = 0..<MemoryLayout<mach_header>.size
                     }
                 default:
@@ -293,8 +291,7 @@ public struct LoadCommand {
             }
             end = offset
         } else {
-            var newheader: mach_header_64
-            let header = newbinary.extract(mach_header_64.self)
+            var header = newbinary.extract(mach_header_64.self)
             var offset = MemoryLayout.size(ofValue: header)
             for _ in 0..<header.ncmds {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
@@ -305,11 +302,10 @@ public struct LoadCommand {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 
-                        newheader = header
-                        newheader.ncmds -= 1
-                        newheader.sizeofcmds -= UInt32(dylib_command.cmdsize)
+                        header.ncmds -= 1
+                        header.sizeofcmds -= UInt32(dylib_command.cmdsize)
 
-                        newHeaderData = Data(bytes: &newheader, count: MemoryLayout<mach_header_64>.size)
+                        newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
                         machoRange = 0..<MemoryLayout<mach_header_64>.size
                     }
                 default:

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -54,7 +54,10 @@ public struct LoadCommand {
                     if isByteSwapped {
                         swap_dylib_command(&command, byteSwappedOrder)
                     }
-                    let curPath = String(data: binary, offset: offset, commandSize: Int(command.cmdsize), loadCommandString: command.dylib.name)
+                    let curPath = String(data: binary,
+                                         offset: offset,
+                                         commandSize: Int(command.cmdsize),
+                                         loadCommandString: command.dylib.name)
                     let curName = curPath.components(separatedBy: "/").last
                     if curName == dylibPath || curPath == dylibPath {
                         print("Load command already exists")
@@ -78,7 +81,10 @@ public struct LoadCommand {
                     if isByteSwapped {
                         swap_dylib_command(&command, byteSwappedOrder)
                     }
-                    let curPath = String(data: binary, offset: offset, commandSize: Int(command.cmdsize), loadCommandString: command.dylib.name)
+                    let curPath = String(data: binary,
+                                         offset: offset,
+                                         commandSize: Int(command.cmdsize),
+                                         loadCommandString: command.dylib.name)
                     let curName = curPath.components(separatedBy: "/").last
                     if curName == dylibPath || curPath == dylibPath {
                         print("Load command already exists")
@@ -188,11 +194,15 @@ public struct LoadCommand {
                         header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
                         let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
 
-                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size, with: newHeaderData)
-                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
-                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize), with: Data(count: Int(command.datasize)))
+                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size,
+                                                  with: newHeaderData)
+                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize),
+                                                  with: Data(count: Int(command.cmdsize)))
+                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize),
+                                                  with: Data(count: Int(command.datasize)))
                     } else {
-                        newbinary.replaceSubrange(offset..<offset + 4, with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                        newbinary.replaceSubrange(offset..<offset + 4,
+                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -209,11 +219,15 @@ public struct LoadCommand {
                         header.sizeofcmds -= UInt32(MemoryLayout<linkedit_data_command>.size)
                         let newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
 
-                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size, with: newHeaderData)
-                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize), with: Data(count: Int(command.cmdsize)))
-                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize), with: Data(count: Int(command.datasize)))
+                        newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size,
+                                                  with: newHeaderData)
+                        newbinary.replaceSubrange(offset..<offset + Int(command.cmdsize),
+                                                  with: Data(count: Int(command.cmdsize)))
+                        newbinary.replaceSubrange(Int(command.dataoff)..<Int(command.dataoff + command.datasize),
+                                                  with: Data(count: Int(command.datasize)))
                     } else {
-                        newbinary.replaceSubrange(offset..<offset + 4, with: Data(bytes: &OP_SOFT_STRIP, count: 4))
+                        newbinary.replaceSubrange(offset..<offset + 4,
+                                                  with: Data(bytes: &OP_SOFT_STRIP, count: 4))
                     }
                 }
                 offset += Int(loadCommand.cmdsize)
@@ -232,7 +246,8 @@ public struct LoadCommand {
             var header = newbinary.extract(mach_header.self)
             if (header.flags & UInt32(MH_PIE)) != 0 {
                 header.flags &= 0xFFDFFFFF
-                newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size, with: Data(bytes: &header, count: MemoryLayout<mach_header>.size))
+                newbinary.replaceSubrange(0..<MemoryLayout<mach_header>.size,
+                                          with: Data(bytes: &header, count: MemoryLayout<mach_header>.size))
             } else {
                 handle(nil)
                 return
@@ -241,7 +256,8 @@ public struct LoadCommand {
             var header = binary.extract(mach_header_64.self)
             if (header.flags & UInt32(MH_PIE)) != 0 {
                 header.flags &= 0xFFDFFFFF
-                newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size, with: Data(bytes: &header, count: MemoryLayout<mach_header_64>.size))
+                newbinary.replaceSubrange(0..<MemoryLayout<mach_header_64>.size,
+                                          with: Data(bytes: &header, count: MemoryLayout<mach_header_64>.size))
             } else {
                 handle(nil)
                 return
@@ -274,7 +290,10 @@ public struct LoadCommand {
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
                     let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
-                    if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
+                    if String.init(data: newbinary,
+                                   offset: offset,
+                                   commandSize: Int(dylib_command.cmdsize),
+                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 
@@ -298,7 +317,10 @@ public struct LoadCommand {
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
                     let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
-                    if String.init(data: newbinary, offset: offset, commandSize: Int(dylib_command.cmdsize), loadCommandString: dylib_command.dylib.name) == dylibPath {
+                    if String.init(data: newbinary,
+                                   offset: offset,
+                                   commandSize: Int(dylib_command.cmdsize),
+                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
                         start = offset
                         size = Int(dylib_command.cmdsize)
 

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -38,7 +38,7 @@ public struct LoadCommand {
                                               type: BitType,
                                               isByteSwapped: Bool,
                                               handle: (Bool) -> Void) {
-        if type == .x64_fat || type == .x86_fat || type == .none {
+        if type == .x64Fat || type == .x86Fat || type == .none {
             handle(false)
             return
         }
@@ -140,20 +140,20 @@ public struct LoadCommand {
                 machoRange = 0..<MemoryLayout<mach_header_64>.size
             }
 
-            let d = String(data: subData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
-            if d != "" && d != nil {
+            let testString = String(data: subData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+            if testString != "" && testString != nil {
                 print("cannot inject payload into \(dylibPath) because there is no room")
                 handle(nil)
                 return
             }
 
-            let dy = dylib(name: lc_str(offset: UInt32(MemoryLayout<dylib_command>.size)),
+            let dylib = dylib(name: lc_str(offset: UInt32(MemoryLayout<dylib_command>.size)),
                            timestamp: 2,
                            current_version: 0,
                            compatibility_version: 0)
             var command = dylib_command(cmd: cmd,
                                         cmdsize: UInt32(cmdsize),
-                                        dylib: dy)
+                                        dylib: dylib)
 
             var commandData = Data(bytes: &command, count: MemoryLayout<dylib_command>.size)
             commandData.append(dylibPath.data(using: String.Encoding.ascii) ?? Data())
@@ -174,7 +174,7 @@ public struct LoadCommand {
                                        type: BitType,
                                        isWeak: Bool,
                                        handle: (Data?) -> Void) {
-        if type == .x64_fat || type == .x86_fat || type == .none {
+        if type == .x64Fat || type == .x86Fat || type == .none {
             handle(nil)
             return
         }
@@ -235,7 +235,7 @@ public struct LoadCommand {
     }
 
     public static func removeASLR(binary: Data, type: BitType, handle: (Data?) -> Void) {
-        if type == .x64_fat || type == .x86_fat || type == .none {
+        if type == .x64Fat || type == .x86Fat || type == .none {
             handle(nil)
             return
         }
@@ -269,7 +269,7 @@ public struct LoadCommand {
                               cmd: UInt32,
                               type: BitType,
                               handle: (Data?) -> Void) {
-        if type == .x64_fat || type == .x86_fat || type == .none {
+        if type == .x64Fat || type == .x86Fat || type == .none {
             handle(nil)
             return
         }
@@ -287,16 +287,16 @@ public struct LoadCommand {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
-                    let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
+                    let dylibCommand = newbinary.extract(dylib_command.self, offset: offset)
                     if String.init(data: newbinary,
                                    offset: offset,
-                                   commandSize: Int(dylib_command.cmdsize),
-                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
+                                   commandSize: Int(dylibCommand.cmdsize),
+                                   loadCommandString: dylibCommand.dylib.name) == dylibPath {
                         start = offset
-                        size = Int(dylib_command.cmdsize)
+                        size = Int(dylibCommand.cmdsize)
 
                         header.ncmds -= 1
-                        header.sizeofcmds -= UInt32(dylib_command.cmdsize)
+                        header.sizeofcmds -= UInt32(dylibCommand.cmdsize)
 
                         newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header>.size)
                         machoRange = 0..<MemoryLayout<mach_header>.size
@@ -314,16 +314,16 @@ public struct LoadCommand {
                 let loadCommand = binary.extract(load_command.self, offset: offset)
                 switch UInt32(loadCommand.cmd) {
                 case LC_REEXPORT_DYLIB, LC_LOAD_WEAK_DYLIB, LC_LOAD_UPWARD_DYLIB, UInt32(LC_LOAD_DYLIB):
-                    let dylib_command = newbinary.extract(dylib_command.self, offset: offset)
+                    let dylibCommand = newbinary.extract(dylib_command.self, offset: offset)
                     if String.init(data: newbinary,
                                    offset: offset,
-                                   commandSize: Int(dylib_command.cmdsize),
-                                   loadCommandString: dylib_command.dylib.name) == dylibPath {
+                                   commandSize: Int(dylibCommand.cmdsize),
+                                   loadCommandString: dylibCommand.dylib.name) == dylibPath {
                         start = offset
-                        size = Int(dylib_command.cmdsize)
+                        size = Int(dylibCommand.cmdsize)
 
                         header.ncmds -= 1
-                        header.sizeofcmds -= UInt32(dylib_command.cmdsize)
+                        header.sizeofcmds -= UInt32(dylibCommand.cmdsize)
 
                         newHeaderData = Data(bytes: &header, count: MemoryLayout<mach_header_64>.size)
                         machoRange = 0..<MemoryLayout<mach_header_64>.size
@@ -339,13 +339,13 @@ public struct LoadCommand {
         if let start = start,
            let end = end,
            let size = size,
-           let mr = machoRange,
-           let nh = newHeaderData {
+           let machoRange = machoRange,
+           let newHeaderData = newHeaderData {
             var commandData = newbinary.subdata(in: start + size..<end)
             commandData.append(Data(count: size))
 
             newbinary.replaceSubrange(start..<end, with: commandData)
-            newbinary.replaceSubrange(mr, with: nh)
+            newbinary.replaceSubrange(machoRange, with: newHeaderData)
         }
 
         handle(newbinary)

--- a/Sources/inject/Command.swift
+++ b/Sources/inject/Command.swift
@@ -10,7 +10,7 @@ import MachO
 
 let byteSwappedOrder = NXByteOrder(rawValue: 0)
 
-public enum LC_Type: String {
+public enum LCType: String {
     case REEXPORT_DYLIB = "LC_REEXPORT_DYLIB"
     case LOAD_WEAK_DYLIB = "LC_LOAD_WEAK_DYLIB"
     case LOAD_UPWARD_DYLIB = "LC_LOAD_UPWARD_DYLIB"
@@ -18,13 +18,13 @@ public enum LC_Type: String {
 
     static func get(_ type: String) -> UInt32 {
         switch type {
-        case LC_Type.REEXPORT_DYLIB.rawValue:
+        case LCType.REEXPORT_DYLIB.rawValue:
             return LC_REEXPORT_DYLIB
-        case LC_Type.LOAD_WEAK_DYLIB.rawValue:
+        case LCType.LOAD_WEAK_DYLIB.rawValue:
             return LC_LOAD_WEAK_DYLIB
-        case LC_Type.LOAD_UPWARD_DYLIB.rawValue:
+        case LCType.LOAD_UPWARD_DYLIB.rawValue:
             return LC_LOAD_UPWARD_DYLIB
-        case LC_Type.LOAD_DYLIB.rawValue:
+        case LCType.LOAD_DYLIB.rawValue:
             return UInt32(LC_LOAD_DYLIB)
         default:
             return 0
@@ -64,7 +64,6 @@ public struct LoadCommand {
                         handle(false)
                         return
                     }
-                    break
                 default:
                     break
                 }
@@ -91,7 +90,6 @@ public struct LoadCommand {
                         handle(false)
                         return
                     }
-                    break
                 default:
                     break
                 }

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -11,7 +11,9 @@ extension Data {
     func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
         let data = self[offset..<offset + MemoryLayout<T>.size]
         return data.withUnsafeBytes { dataBytes in
-            dataBytes.baseAddress!.assumingMemoryBound(to: UInt8.self).withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
+            dataBytes.baseAddress!
+                .assumingMemoryBound(to: UInt8.self)
+                .withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
                 return p.pointee
             }
         }

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -29,7 +29,7 @@ extension String {
         }
         self.init(string)
     }
-    
+
     init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -13,8 +13,8 @@ extension Data {
         return data.withUnsafeBytes { dataBytes in
             dataBytes.baseAddress!
                 .assumingMemoryBound(to: UInt8.self)
-                .withMemoryRebound(to: T.self, capacity: 1) { (p) -> T in
-                return p.pointee
+                .withMemoryRebound(to: T.self, capacity: 1) { (pointer) -> T in
+                return pointer.pointee
             }
         }
     }

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by paradiseduo on 2021/9/10.
 //
@@ -39,7 +39,7 @@ extension String {
 }
 
 extension FileManager {
-    static func open(machoPath: String, backup: Bool, handle: (Data?)->()) {
+    static func open(machoPath: String, backup: Bool, handle: (Data?) -> Void) {
         do {
             if FileManager.default.fileExists(atPath: machoPath) {
                 if backup {

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -21,22 +21,12 @@ extension Data {
 }
 
 extension String {
-    init(_ rawCString: (Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8, Int8)) {
-        var rawCString = rawCString
-        let rawCStringSize = MemoryLayout.size(ofValue: rawCString)
-        let string = withUnsafePointer(to: &rawCString) { (pointer) -> String in
-            return pointer.withMemoryRebound(to: UInt8.self, capacity: rawCStringSize, {
-                return String(cString: $0)
-            })
-        }
-        self.init(string)
-    }
-
     init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
         let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)], encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        self = String(data: data[stringOffset..<(stringOffset + length)],
+                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
     }
 }
 

--- a/Sources/inject/Inject.swift
+++ b/Sources/inject/Inject.swift
@@ -109,7 +109,7 @@ extension Inject {
         } else if injectPath.hasSuffix(".dylib") {
             iName = injectFilePath.components(separatedBy: "/").last!
             iPath = injectFilePath
-            
+
             if components.count > 1 {
                 if components.first!.hasPrefix("@") {
                     injectPathNew = "\(components.first!)/Inject/\(iName)"

--- a/Sources/inject/Inject.swift
+++ b/Sources/inject/Inject.swift
@@ -41,15 +41,15 @@ struct Inject: ParsableCommand {
     var weak = true
 
     mutating func run() throws {
-        let cmd_type = LCType.get(cmd)
-        if cmd_type == 0 {
+        let cmdType = LCType.get(cmd)
+        if cmdType == 0 {
             print("Invalid load command type")
             return
         }
 
         if ipa {
             injectIPA(ipaPath: filePath,
-                      cmd_type: cmd_type,
+                      cmdType: cmdType,
                       injectPath: dylib) { success in
                 if !success {
                     print("Inject IPA Fail")
@@ -57,7 +57,7 @@ struct Inject: ParsableCommand {
             }
         } else {
             injectMachO(machoPath: filePath,
-                        cmd_type: cmd_type,
+                        cmdType: cmdType,
                         backup: true,
                         injectPath: dylib) { success in
                 if !success {
@@ -70,7 +70,7 @@ struct Inject: ParsableCommand {
 
 extension Inject {
     private func injectIPA(ipaPath: String,
-                           cmd_type: UInt32,
+                           cmdType: UInt32,
                            injectPath: String,
                            finishHandle: (Bool) -> Void) {
         var result = false
@@ -171,7 +171,7 @@ extension Inject {
                                                      toPath: "\(appPath)/Inject/\(iName)")
 
                     injectMachO(machoPath: machoPath,
-                                cmd_type: cmd_type,
+                                cmdType: cmdType,
                                 backup: false,
                                 injectPath: injectPathNew) { success in
                         if success {
@@ -197,7 +197,7 @@ extension Inject {
     }
 
     private func injectMachO(machoPath: String,
-                             cmd_type: UInt32,
+                             cmdType: UInt32,
                              backup: Bool,
                              injectPath: String,
                              finishHandle: (Bool) -> Void) {
@@ -210,7 +210,7 @@ extension Inject {
                         if remove {
                             LoadCommand.remove(binary: binary,
                                                dylibPath: injectPath,
-                                               cmd: cmd_type,
+                                               cmd: cmdType,
                                                type: type) { newBinary in
                                 result = Inject.writeFile(newBinary: newBinary,
                                                           machoPath: machoPath,
@@ -224,7 +224,7 @@ extension Inject {
                                                                isByteSwapped: isByteSwapped) { canInject in
                                 LoadCommand.inject(binary: binary,
                                                    dylibPath: injectPath,
-                                                   cmd: cmd_type, type: type,
+                                                   cmd: cmdType, type: type,
                                                    canInject: canInject) { newBinary in
                                     result = Inject.writeFile(newBinary: newBinary,
                                                               machoPath: machoPath,

--- a/Sources/inject/Inject.swift
+++ b/Sources/inject/Inject.swift
@@ -156,12 +156,10 @@ extension Inject {
                     let fileList = try FileManager.default.contentsOfDirectory(atPath: payload)
                     var machoPath = ""
                     var appPath = ""
-                    for item in fileList {
-                        if item.hasSuffix(".app") {
-                            appPath = payload + "/\(item)"
-                            machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
-                            break
-                        }
+                    for item in fileList where item.hasSuffix(".app") {
+                        appPath = payload + "/\(item)"
+                        machoPath = appPath+"/\(item.components(separatedBy: ".")[0])"
+                        break
                     }
 
                     try FileManager.default.createDirectory(atPath: "\(appPath)/Inject/",

--- a/Sources/inject/Shell.swift
+++ b/Sources/inject/Shell.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct Shell {
-    public static func run(_ command: String, handle:(Int32, String) -> Void) {
+    public static func run(_ command: String, handle: (Int32, String) -> Void) {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]
@@ -18,7 +18,7 @@ public struct Shell {
         task.standardError = pipe
 
         task.launch()
-        
+
         let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: String.Encoding.utf8)
 
         task.waitUntilExit()

--- a/Sources/inject/Shell.swift
+++ b/Sources/inject/Shell.swift
@@ -8,19 +8,19 @@
 import Foundation
 
 public struct Shell {
-    public static func run(_ command: String, handle:(Int32, String)->()) {
+    public static func run(_ command: String, handle:(Int32, String) -> Void) {
         let task = Process()
         task.launchPath = "/bin/bash"
         task.arguments = ["-c", command]
-        
+
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = pipe
-        
+
         task.launch()
         
         let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: String.Encoding.utf8)
-        
+
         task.waitUntilExit()
         handle(task.terminationStatus, output ?? "")
     }

--- a/Tests/InjectTests/InjectTests.swift
+++ b/Tests/InjectTests/InjectTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import class Foundation.Bundle
 
-final class injectTests: XCTestCase {
+final class InjectTests: XCTestCase {
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct


### PR DESCRIPTION
@paradiseduo I suggest splitting the Inject library and the CLI into two projects. That way you can avoid creating duplicate files in the `Sources/inject/` folder

- Whitespace/other styling checked with SwiftLint
- Cleanup of unnecessary `Range(NSRange())`
- Cleanup of some variables and such
- Make things more Swifty