### PR TITLE
fix: read Mach-O load command string until null terminator

### DIFF
--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -25,8 +25,9 @@ extension String {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
         let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        let rawData = data[stringOffset..<(stringOffset + length)]
+        let endIndex = rawData.firstIndex(of: 0x00) ?? rawData.endIndex
+        self = String(data: data[stringOffset..<endIndex], encoding: .utf8)!
     }
 }
 


### PR DESCRIPTION
## Summary

Fix `String.init(data:offset:commandSize:loadCommandString:)` in `Extension.swift` to stop reading at the first null byte (`0x00`) instead of consuming the entire load command region.

## Problem

Mach-O load commands are padded to alignment boundaries. The padding bytes after the null terminator are not guaranteed to be valid UTF-8 — for example, bytes like `0xC5 0x0F` have been observed in real-world binaries. The current implementation reads the full `commandSize - stringOffset` range and calls `.trimmingCharacters(in: .controlCharacters)`, which only strips leading/trailing control characters but does **not** handle arbitrary non-UTF-8 bytes embedded in the padding region. This causes `String(data:encoding:.utf8)` to return `nil`, triggering a force-unwrap crash.

## Fix

Read up to `commandSize` bytes, but stop at the first `0x00` null terminator before attempting UTF-8 decoding. This matches how C strings are conventionally terminated in Mach-O structures.

```diff
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        let rawData = data[stringOffset..<(stringOffset + length)]
+        let endIndex = rawData.firstIndex(of: 0x00) ?? rawData.endIndex
+        self = String(data: data[stringOffset..<endIndex], encoding: .utf8)!
```
