### PR TITLE
Fix malformed Mach-O load command parsing in the CLI target

### DIFF
--- a/Injection/Injection/Extension.swift
+++ b/Injection/Injection/Extension.swift
@@ -24,10 +24,19 @@ extension String {
     init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
-        let length = commandSize - loadCommandStringOffset
-        let rawData = data[stringOffset..<(stringOffset + length)]
-        let endIndex = rawData.firstIndex(of: 0x00) ?? rawData.endIndex
-        self = String(data: data[stringOffset..<endIndex], encoding: .utf8)!
+        let commandEnd = offset + commandSize
+
+        guard loadCommandStringOffset > 0,
+              stringOffset >= data.startIndex,
+              stringOffset <= commandEnd,
+              commandEnd <= data.endIndex else {
+            self = ""
+            return
+        }
+
+        let rawData = data[stringOffset..<commandEnd].prefix { $0 != 0 }
+        self = String(decoding: rawData, as: UTF8.self)
+            .trimmingCharacters(in: .controlCharacters)
     }
 }
 

--- a/Sources/inject/Extension.swift
+++ b/Sources/inject/Extension.swift
@@ -24,9 +24,19 @@ extension String {
     init(data: Data, offset: Int, commandSize: Int, loadCommandString: lc_str) {
         let loadCommandStringOffset = Int(loadCommandString.offset)
         let stringOffset = offset + loadCommandStringOffset
-        let length = commandSize - loadCommandStringOffset
-        self = String(data: data[stringOffset..<(stringOffset + length)],
-                      encoding: .utf8)!.trimmingCharacters(in: .controlCharacters)
+        let commandEnd = offset + commandSize
+
+        guard loadCommandStringOffset > 0,
+              stringOffset >= data.startIndex,
+              stringOffset <= commandEnd,
+              commandEnd <= data.endIndex else {
+            self = ""
+            return
+        }
+
+        let rawData = data[stringOffset..<commandEnd].prefix { $0 != 0 }
+        self = String(decoding: rawData, as: UTF8.self)
+            .trimmingCharacters(in: .controlCharacters)
     }
 }
 


### PR DESCRIPTION
## Summary
This fixes the malformed Mach-O load command string crash in the `inject` executable.

`1.2.1` updated `Injection/Injection/Extension.swift`, but `Sources/inject/Extension.swift` was still using the older force-unwrapped parser. This change makes both targets handle invalid UTF-8 and out-of-range load-command offsets safely instead of trapping.

## Scope
- fix `Sources/inject/Extension.swift`
- align `Injection/Injection/Extension.swift` with the same safe parsing behavior
